### PR TITLE
feat(detect): async detectAsync worker isolate + direct NV21->ARGB conversion (closes #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### **Features**
 
-* **Configurable image conversion mode** (`ConversionMode`): choose between the new `ConversionMode.direct` (default) — a direct NV21→ARGB pixel-by-pixel conversion that skips the per-frame JPEG encode/decode (~3–8 ms saved per frame) — or `ConversionMode.jpeg(quality: q)` to retain the previous JPEG round-trip path. `sync detect()` and `createAsync()` both default to `direct`.
+* **Faster frame conversion**: camera frames now convert via a direct NV21→ARGB pixel path that skips the per-frame JPEG encode/decode round-trip (~3–8 ms saved per frame). Applies to both `detect()` and `detectAsync()`.
 * **Async detection via worker isolate** (`createAsync` / `detectAsync`): `HandLandmarkerPlugin.createAsync(...)` spawns a dedicated Dart isolate that owns the native MediaPipe handle. `detectAsync(CameraImage, int)` offloads the blocking JNI call to the worker, keeping the main isolate free. Only `Uint8List` and `int` primitives cross the isolate port boundary (no JNI handles). The worker shuts down gracefully on `dispose()`, draining any in-flight detection before exiting.
 * **`disposeAsync()`**: optional async dispose that awaits worker shutdown completion.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ All notable changes to this project will be documented in this file.
 * **Faster frame conversion**: camera frames now convert via a direct NV21→ARGB pixel path that skips the per-frame JPEG encode/decode round-trip (~3–8 ms saved per frame). Applies to both `detect()` and `detectAsync()`.
 * **Async detection via worker isolate** (`createAsync` / `detectAsync`): `HandLandmarkerPlugin.createAsync(...)` spawns a dedicated Dart isolate that owns the native MediaPipe handle. `detectAsync(CameraImage, int)` offloads the blocking JNI call to the worker, keeping the main isolate free. Only `Uint8List` and `int` primitives cross the isolate port boundary (no JNI handles). The worker shuts down gracefully on `dispose()`, draining any in-flight detection before exiting.
 * **`disposeAsync()`**: optional async dispose that awaits worker shutdown completion.
+* **`detectAsync` request guards**: optional `timeout` (default 5s) evicts a frame whose worker reply never arrives and completes it with `TimeoutException` instead of hanging; optional `dropIfBusy` drops frames submitted while a detection is in flight, bounding the worker queue.
 
 ### **Bug Fixes**
 
 * **Native handle leak fixed**: `HandLandmarker.close()` is now called on dispose (both sync and async paths), preventing MediaPipe native resource leaks that existed in prior versions.
+* **Native buffer leak on error paths fixed**: the YUV `JByteBuffer`s and result `JString` are now released in a `finally` block on both `detect()` and the worker path, so a throwing detection no longer leaks native buffers per frame.
 
 ### **Notes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## **2.3.0 - 2026-06-16**
+
+### **Features**
+
+* **Configurable image conversion mode** (`ConversionMode`): choose between the new `ConversionMode.direct` (default) — a direct NV21→ARGB pixel-by-pixel conversion that skips the per-frame JPEG encode/decode (~3–8 ms saved per frame) — or `ConversionMode.jpeg(quality: q)` to retain the previous JPEG round-trip path. `sync detect()` and `createAsync()` both default to `direct`.
+* **Async detection via worker isolate** (`createAsync` / `detectAsync`): `HandLandmarkerPlugin.createAsync(...)` spawns a dedicated Dart isolate that owns the native MediaPipe handle. `detectAsync(CameraImage, int)` offloads the blocking JNI call to the worker, keeping the main isolate free. Only `Uint8List` and `int` primitives cross the isolate port boundary (no JNI handles). The worker shuts down gracefully on `dispose()`, draining any in-flight detection before exiting.
+* **`disposeAsync()`**: optional async dispose that awaits worker shutdown completion.
+
+### **Bug Fixes**
+
+* **Native handle leak fixed**: `HandLandmarker.close()` is now called on dispose (both sync and async paths), preventing MediaPipe native resource leaks that existed in prior versions.
+
+### **Notes**
+
+* Sync `detect()` / `create()` signatures are unchanged — this release is fully backward-compatible.
+* Using both `create()` and `createAsync()` simultaneously loads two native model instances (expected behavior; each instance owns its own handle).
+
 ## **2.2.0 - 2025-12-13**
 
 ### **💥 Breaking Changes**

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ This plugin provides a simple Dart API that hides the complexity of native code 
 
 * **Live Hand Tracking**: Performs real-time detection of hand landmarks from a CameraImage stream.  
 * **High Performance & Customizable**: Leverages the native Android MediaPipe library with a configurable **delegate (GPU or CPU)** for highly performant ML inference. You can also configure the number of hands to detect and the detection confidence. 
+* **Configurable Conversion Mode**: Choose between `ConversionMode.direct` (default, ~3–8 ms faster per frame — skips JPEG round-trip) or `ConversionMode.jpeg(quality: q)` for the legacy JPEG encode/decode path.
+* **Non-blocking Async Detection**: Use `createAsync()` and `detectAsync()` to run inference on a dedicated worker isolate, keeping the main thread free.
 * **Simple, Type-Safe API**: Provides clean Dart data models (Hand, Landmark) for the detection results.  
-* **Resource Management**: Includes a dispose() method to properly clean up all native resources.  
+* **Resource Management**: Includes a `dispose()` method to properly clean up all native resources (including the native MediaPipe handle).  
 * **Bundled Model**: The required [hand_landmarker.task](https://ai.google.dev/edge/mediapipe/solutions/vision/hand_landmarker#models) model is bundled with the plugin, so no manual setup is required.
 
 ## How it Works
@@ -40,7 +42,7 @@ Add the following dependencies to your app's pubspec.yaml file:
 
 ```yaml
 dependencies:  
-  hand_landmarker: ^2.2.0 # Use the latest version
+  hand_landmarker: ^2.3.0 # Use the latest version
 ```
 
 Then, run `flutter pub get`.
@@ -175,6 +177,74 @@ You can now use the `_landmarks` list in a `CustomPainter` to draw the results o
   }  
 }
 ```
+
+## Conversion Mode
+
+`ConversionMode` controls how YUV camera frames are converted to a bitmap before MediaPipe inference.
+
+| Mode | Description |
+|------|-------------|
+| `ConversionMode.direct` (default) | Direct NV21→ARGB pixel conversion. No JPEG encode/decode. ~3–8 ms faster per frame. |
+| `ConversionMode.jpeg(quality: q)` | Encode NV21 to JPEG at quality `q` (1–100), then decode. Legacy behavior. |
+
+```dart
+// Default (direct, no JPEG):
+final plugin = HandLandmarkerPlugin.create();
+
+// Explicit direct:
+final plugin = HandLandmarkerPlugin.create(
+  conversionMode: ConversionMode.direct,
+);
+
+// JPEG path at quality 85:
+final plugin = HandLandmarkerPlugin.create(
+  conversionMode: ConversionMode.jpeg(quality: 85),
+);
+```
+
+The same `conversionMode` parameter is available on `createAsync()`.
+
+## Async Detection (Worker Isolate)
+
+`createAsync()` spawns a dedicated Dart isolate that owns the native MediaPipe model. Calling `detectAsync()` sends a frame to the worker and awaits the result, without blocking the main isolate.
+
+```dart
+Future<void> _initialize() async {
+  _plugin = await HandLandmarkerPlugin.createAsync(
+    numHands: 2,
+    minHandDetectionConfidence: 0.7,
+    delegate: HandLandmarkerDelegate.gpu,
+    // conversionMode defaults to ConversionMode.direct
+  );
+  // ...
+}
+
+Future<void> _processCameraImage(CameraImage image) async {
+  if (_isDetecting || _plugin == null) return;
+  _isDetecting = true;
+  try {
+    final hands = await _plugin!.detectAsync(
+      image,
+      _controller!.description.sensorOrientation,
+    );
+    setState(() => _landmarks = hands);
+  } finally {
+    _isDetecting = false;
+  }
+}
+
+@override
+void dispose() {
+  _plugin?.dispose(); // signals worker to shut down gracefully
+  super.dispose();
+}
+```
+
+**Notes:**
+- Only `Uint8List` and `int` primitives cross the isolate port — no JNI handles.
+- `dispose()` is synchronous (backward-compatible). Use `disposeAsync()` if you need to await full worker shutdown.
+- Using `create()` and `createAsync()` simultaneously loads two native model instances (each owns its own handle).
+- Calling `detect()` on an async instance (or `detectAsync()` on a sync instance) throws `StateError`.
 
 ## Data Models
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin provides a simple Dart API that hides the complexity of native code 
 
 * **Live Hand Tracking**: Performs real-time detection of hand landmarks from a CameraImage stream.  
 * **High Performance & Customizable**: Leverages the native Android MediaPipe library with a configurable **delegate (GPU or CPU)** for highly performant ML inference. You can also configure the number of hands to detect and the detection confidence. 
-* **Configurable Conversion Mode**: Choose between `ConversionMode.direct` (default, ~3–8 ms faster per frame — skips JPEG round-trip) or `ConversionMode.jpeg(quality: q)` for the legacy JPEG encode/decode path.
+* **Fast Frame Conversion**: Converts camera frames via a direct NV21→ARGB path (no JPEG encode/decode round-trip), ~3–8 ms faster per frame.
 * **Non-blocking Async Detection**: Use `createAsync()` and `detectAsync()` to run inference on a dedicated worker isolate, keeping the main thread free.
 * **Simple, Type-Safe API**: Provides clean Dart data models (Hand, Landmark) for the detection results.  
 * **Resource Management**: Includes a `dispose()` method to properly clean up all native resources (including the native MediaPipe handle).  
@@ -178,32 +178,6 @@ You can now use the `_landmarks` list in a `CustomPainter` to draw the results o
 }
 ```
 
-## Conversion Mode
-
-`ConversionMode` controls how YUV camera frames are converted to a bitmap before MediaPipe inference.
-
-| Mode | Description |
-|------|-------------|
-| `ConversionMode.direct` (default) | Direct NV21→ARGB pixel conversion. No JPEG encode/decode. ~3–8 ms faster per frame. |
-| `ConversionMode.jpeg(quality: q)` | Encode NV21 to JPEG at quality `q` (1–100), then decode. Legacy behavior. |
-
-```dart
-// Default (direct, no JPEG):
-final plugin = HandLandmarkerPlugin.create();
-
-// Explicit direct:
-final plugin = HandLandmarkerPlugin.create(
-  conversionMode: ConversionMode.direct,
-);
-
-// JPEG path at quality 85:
-final plugin = HandLandmarkerPlugin.create(
-  conversionMode: ConversionMode.jpeg(quality: 85),
-);
-```
-
-The same `conversionMode` parameter is available on `createAsync()`.
-
 ## Async Detection (Worker Isolate)
 
 `createAsync()` spawns a dedicated Dart isolate that owns the native MediaPipe model. Calling `detectAsync()` sends a frame to the worker and awaits the result, without blocking the main isolate.
@@ -214,7 +188,6 @@ Future<void> _initialize() async {
     numHands: 2,
     minHandDetectionConfidence: 0.7,
     delegate: HandLandmarkerDelegate.gpu,
-    // conversionMode defaults to ConversionMode.direct
   );
   // ...
 }

--- a/README.md
+++ b/README.md
@@ -213,6 +213,20 @@ void dispose() {
 }
 ```
 
+`detectAsync` accepts two optional guards:
+
+```dart
+final hands = await _plugin!.detectAsync(
+  image,
+  sensorOrientation,
+  timeout: const Duration(seconds: 5), // evict the frame if the worker never replies
+  dropIfBusy: true,                     // skip frames while a detection is in flight
+);
+```
+
+- `timeout` (default 5s) completes the future with a `TimeoutException` and evicts the request if the worker reply never arrives (e.g. the worker died mid-frame), so the call never hangs forever.
+- `dropIfBusy` (default `false`) returns an empty list immediately when a detection is already in flight, bounding the worker queue. With it off, you own the pacing (the example self-guards with `_isDetecting`).
+
 **Notes:**
 - Only `Uint8List` and `int` primitives cross the isolate port — no JNI handles.
 - `dispose()` is synchronous (backward-compatible). Use `disposeAsync()` if you need to await full worker shutdown.

--- a/android/src/main/kotlin/io/github/iot_gamer/hand_landmarker/MyHandLandmarker.kt
+++ b/android/src/main/kotlin/io/github/iot_gamer/hand_landmarker/MyHandLandmarker.kt
@@ -37,9 +37,38 @@ class MyHandLandmarker(private val context: Context) {
         handLandmarker = HandLandmarker.createFromOptions(context, options)
     }
 
+    fun close() {
+        handLandmarker?.close()
+        handLandmarker = null
+    }
+
+    private fun nv21ToArgbBitmap(nv21: ByteArray, width: Int, height: Int): Bitmap {
+        val argb = IntArray(width * height)
+        val frameSize = width * height
+        for (j in 0 until height) {
+            for (i in 0 until width) {
+                val yIdx = j * width + i
+                // NV21: UV interleaved after Y plane; each UV pair covers 2x2 block
+                // NV21 order is V then U
+                val uvIdx = frameSize + (j / 2) * width + (i and 1.inv())
+                val yy = nv21[yIdx].toInt() and 0xFF
+                val vv = (nv21[uvIdx].toInt() and 0xFF) - 128
+                val uu = (nv21[uvIdx + 1].toInt() and 0xFF) - 128
+                var r = yy + (1.402f * vv).toInt()
+                var g = yy - (0.344136f * uu).toInt() - (0.714136f * vv).toInt()
+                var b = yy + (1.772f * uu).toInt()
+                r = r.coerceIn(0, 255)
+                g = g.coerceIn(0, 255)
+                b = b.coerceIn(0, 255)
+                argb[yIdx] = (0xFF000000.toInt()) or (r shl 16) or (g shl 8) or b
+            }
+        }
+        return Bitmap.createBitmap(argb, width, height, Bitmap.Config.ARGB_8888)
+    }
+
     /**
      * Detects hand landmarks from YUV image planes.
-     * This method is more efficient as it avoids YUV->RGBA conversion in Dart.
+     * conversionMode: 0 = direct NV21->ARGB (no JPEG round-trip), 1 = JPEG encode/decode path.
      */
     fun detectFromYuv(
         yBuffer: ByteBuffer,
@@ -50,26 +79,26 @@ class MyHandLandmarker(private val context: Context) {
         yRowStride: Int,
         uvRowStride: Int,
         uvPixelStride: Int,
-        rotation: Int
+        rotation: Int,
+        conversionMode: Int,
+        jpegQuality: Int
     ): String {
         if (handLandmarker == null) {
-            // Default initialization if not already configured
             initialize(2, 0.5f, true)
         }
 
-        // 1. Convert YUV planes to a Bitmap.
         val yuvBytes = convertYuvToNv21(yBuffer, uBuffer, vBuffer, width, height, yRowStride, uvRowStride, uvPixelStride)
 
-        // Create a YuvImage from the NV21 data.
-        val yuvImage = YuvImage(yuvBytes, ImageFormat.NV21, width, height, null)
-
-        // Create a ByteArrayOutputStream and compress the YuvImage to a JPEG.
-        val out = ByteArrayOutputStream()
-        yuvImage.compressToJpeg(Rect(0, 0, width, height), 100, out)
-        val imageBytes = out.toByteArray()
-
-        // Decode the JPEG bytes into a Bitmap.
-        var bitmap = android.graphics.BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+        // 1. Convert YUV planes to a Bitmap.
+        val bitmap: Bitmap = if (conversionMode == 0) {
+            nv21ToArgbBitmap(yuvBytes, width, height)
+        } else {
+            val yuvImage = YuvImage(yuvBytes, ImageFormat.NV21, width, height, null)
+            val out = ByteArrayOutputStream()
+            yuvImage.compressToJpeg(Rect(0, 0, width, height), jpegQuality, out)
+            val imageBytes = out.toByteArray()
+            android.graphics.BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
+        }
 
         // 2. Create an MPImage from the Bitmap.
         val mpImage = BitmapImageBuilder(bitmap).build()

--- a/android/src/main/kotlin/io/github/iot_gamer/hand_landmarker/MyHandLandmarker.kt
+++ b/android/src/main/kotlin/io/github/iot_gamer/hand_landmarker/MyHandLandmarker.kt
@@ -2,16 +2,12 @@ package io.github.iot_gamer.hand_landmarker
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.ImageFormat
-import android.graphics.Rect
-import android.graphics.YuvImage
 import com.google.mediapipe.framework.image.BitmapImageBuilder
 import com.google.mediapipe.framework.image.MPImage
 import com.google.mediapipe.tasks.core.BaseOptions
 import com.google.mediapipe.tasks.core.Delegate
 import com.google.mediapipe.tasks.vision.core.ImageProcessingOptions
 import com.google.mediapipe.tasks.vision.handlandmarker.HandLandmarker
-import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 
 class MyHandLandmarker(private val context: Context) {
@@ -68,7 +64,7 @@ class MyHandLandmarker(private val context: Context) {
 
     /**
      * Detects hand landmarks from YUV image planes.
-     * conversionMode: 0 = direct NV21->ARGB (no JPEG round-trip), 1 = JPEG encode/decode path.
+     * Converts NV21 directly to ARGB (no JPEG round-trip).
      */
     fun detectFromYuv(
         yBuffer: ByteBuffer,
@@ -79,9 +75,7 @@ class MyHandLandmarker(private val context: Context) {
         yRowStride: Int,
         uvRowStride: Int,
         uvPixelStride: Int,
-        rotation: Int,
-        conversionMode: Int,
-        jpegQuality: Int
+        rotation: Int
     ): String {
         if (handLandmarker == null) {
             initialize(2, 0.5f, true)
@@ -89,16 +83,8 @@ class MyHandLandmarker(private val context: Context) {
 
         val yuvBytes = convertYuvToNv21(yBuffer, uBuffer, vBuffer, width, height, yRowStride, uvRowStride, uvPixelStride)
 
-        // 1. Convert YUV planes to a Bitmap.
-        val bitmap: Bitmap = if (conversionMode == 0) {
-            nv21ToArgbBitmap(yuvBytes, width, height)
-        } else {
-            val yuvImage = YuvImage(yuvBytes, ImageFormat.NV21, width, height, null)
-            val out = ByteArrayOutputStream()
-            yuvImage.compressToJpeg(Rect(0, 0, width, height), jpegQuality, out)
-            val imageBytes = out.toByteArray()
-            android.graphics.BitmapFactory.decodeByteArray(imageBytes, 0, imageBytes.size)
-        }
+        // 1. Convert YUV planes to a Bitmap (direct NV21->ARGB).
+        val bitmap: Bitmap = nv21ToArgbBitmap(yuvBytes, width, height)
 
         // 2. Create an MPImage from the Bitmap.
         val mpImage = BitmapImageBuilder(bitmap).build()

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,7 +42,7 @@ class _HandTrackerViewState extends State<HandTrackerView> {
   List<Hand> _landmarks = [];
   // A flag to show a loading indicator while the camera and plugin are initializing.
   bool _isInitialized = false;
-  // A guard to prevent processing multiple frames at once.
+  // A guard to prevent unbounded Completer accumulation at 30fps.
   bool _isDetecting = false;
 
   @override
@@ -62,8 +62,8 @@ class _HandTrackerViewState extends State<HandTrackerView> {
       enableAudio: false,
     );
 
-    // Create an instance of our plugin with custom options.
-    _plugin = HandLandmarkerPlugin.create(
+    // Create an async instance that runs JNI on a worker isolate.
+    _plugin = await HandLandmarkerPlugin.createAsync(
       numHands: 2,
       minHandDetectionConfidence: 0.7,
       delegate: HandLandmarkerDelegate.gpu,
@@ -95,8 +95,7 @@ class _HandTrackerViewState extends State<HandTrackerView> {
     _isDetecting = true;
 
     try {
-      // The detect method is now synchronous (not async).
-      final hands = _plugin!.detect(
+      final hands = await _plugin!.detectAsync(
         image,
         _controller!.description.sensorOrientation,
       );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -176,7 +176,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.2"
+    version: "2.3.0"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -226,26 +226,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   package_config:
     dependency: transitive
     description:
@@ -351,10 +351,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -388,5 +388,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.35.6"

--- a/lib/hand_landmarker.dart
+++ b/lib/hand_landmarker.dart
@@ -229,6 +229,20 @@ class HandLandmarkerPlugin {
 
   bool get _isAsync => _isolate != null;
 
+  /// Creates a stub instance with [_disposed] pre-set to true, for use in unit
+  /// tests asserting post-dispose [StateError] guards without a live JNI/isolate.
+  @visibleForTesting
+  factory HandLandmarkerPlugin.disposedForTesting() {
+    final inst = HandLandmarkerPlugin._(null, null);
+    inst._disposed = true;
+    return inst;
+  }
+
+  /// Returns true if this instance has been disposed.
+  /// Exposed for unit testing the dispose state guard without invoking JNI.
+  @visibleForTesting
+  bool get isDisposedForTesting => _disposed;
+
   /// Creates and initializes the Hand Landmarker (sync, blocking on the calling thread).
   static HandLandmarkerPlugin create({
     int numHands = 2,
@@ -438,6 +452,10 @@ class FrameRequestTestHelper {
     );
   }
 }
+
+/// Exposed for unit testing — calls the real internal parse function.
+@visibleForTesting
+List<Hand> parseHandsForTesting(String resultString) => _parseHands(resultString);
 
 List<Hand> _parseHands(String resultString) {
   if (resultString.isEmpty || resultString == '[]') return [];

--- a/lib/hand_landmarker.dart
+++ b/lib/hand_landmarker.dart
@@ -29,39 +29,6 @@ class Landmark {
 
 enum HandLandmarkerDelegate { cpu, gpu }
 
-// --- ConversionMode ---
-
-sealed class ConversionMode {
-  const ConversionMode();
-
-  static const ConversionMode direct = _Direct();
-
-  factory ConversionMode.jpeg({int quality = 90}) => _Jpeg(quality: quality);
-
-  /// Returns the (conversionMode, jpegQuality) pair for the JNI boundary.
-  (int conversionMode, int jpegQuality) get _params;
-
-  /// Exposed for testing only — returns (conversionMode, jpegQuality).
-  @visibleForTesting
-  (int, int) get paramsForTesting => _params;
-}
-
-class _Direct extends ConversionMode {
-  const _Direct();
-
-  @override
-  (int, int) get _params => (0, 90);
-}
-
-class _Jpeg extends ConversionMode {
-  final int quality;
-
-  const _Jpeg({required this.quality});
-
-  @override
-  (int, int) get _params => (1, quality);
-}
-
 // --- Worker isolate messages (only bytes/ints/Strings cross the port) ---
 
 class _InitMsg {
@@ -69,16 +36,12 @@ class _InitMsg {
   final int numHands;
   final double minHandDetectionConfidence;
   final bool useGpu;
-  final int conversionMode;
-  final int jpegQuality;
 
   _InitMsg({
     required this.replyPort,
     required this.numHands,
     required this.minHandDetectionConfidence,
     required this.useGpu,
-    required this.conversionMode,
-    required this.jpegQuality,
   });
 }
 
@@ -204,8 +167,6 @@ void _workerEntry(_InitMsg msg) {
           message.uvRowStride,
           message.uvPixelStride,
           message.rotation,
-          msg.conversionMode,
-          msg.jpegQuality,
         );
         final json = resultJString.toDartString();
 
@@ -236,7 +197,6 @@ void _workerEntry(_InitMsg msg) {
 class HandLandmarkerPlugin {
   // Sync instance fields
   final MyHandLandmarker? _landmarker;
-  final ConversionMode? _conversionMode;
 
   // Async instance fields
   final Isolate? _isolate;
@@ -251,15 +211,14 @@ class HandLandmarkerPlugin {
   Completer<void>? _closedAck;
 
   /// Private constructor for sync instances.
-  HandLandmarkerPlugin._(this._landmarker, this._conversionMode)
+  HandLandmarkerPlugin._(this._landmarker)
       : _isolate = null,
         _workerPort = null,
         _recvPort = null;
 
   /// Private constructor for async instances.
   HandLandmarkerPlugin._async(this._isolate, this._workerPort, this._recvPort)
-      : _landmarker = null,
-        _conversionMode = null;
+      : _landmarker = null;
 
   bool get _isAsync => _isolate != null;
 
@@ -267,7 +226,7 @@ class HandLandmarkerPlugin {
   /// tests asserting post-dispose [StateError] guards without a live JNI/isolate.
   @visibleForTesting
   factory HandLandmarkerPlugin.disposedForTesting() {
-    final inst = HandLandmarkerPlugin._(null, null);
+    final inst = HandLandmarkerPlugin._(null);
     inst._disposed = true;
     return inst;
   }
@@ -282,7 +241,6 @@ class HandLandmarkerPlugin {
     int numHands = 2,
     double minHandDetectionConfidence = 0.5,
     HandLandmarkerDelegate delegate = HandLandmarkerDelegate.gpu,
-    ConversionMode conversionMode = ConversionMode.direct,
   }) {
     final contextObj = Jni.androidApplicationContext;
     final landmarker = MyHandLandmarker(contextObj);
@@ -291,7 +249,7 @@ class HandLandmarkerPlugin {
       minHandDetectionConfidence,
       delegate == HandLandmarkerDelegate.gpu,
     );
-    return HandLandmarkerPlugin._(landmarker, conversionMode);
+    return HandLandmarkerPlugin._(landmarker);
   }
 
   /// Creates and initializes the Hand Landmarker on a dedicated worker isolate.
@@ -299,18 +257,14 @@ class HandLandmarkerPlugin {
     int numHands = 2,
     double minHandDetectionConfidence = 0.5,
     HandLandmarkerDelegate delegate = HandLandmarkerDelegate.gpu,
-    ConversionMode conversionMode = ConversionMode.direct,
   }) async {
     final recvPort = ReceivePort();
-    final (cm, jq) = conversionMode._params;
 
     final initMsg = _InitMsg(
       replyPort: recvPort.sendPort,
       numHands: numHands,
       minHandDetectionConfidence: minHandDetectionConfidence,
       useGpu: delegate == HandLandmarkerDelegate.gpu,
-      conversionMode: cm,
-      jpegQuality: jq,
     );
 
     final isolate = await Isolate.spawn(_workerEntry, initMsg,
@@ -351,8 +305,6 @@ class HandLandmarkerPlugin {
       throw StateError('detect() called on async instance — use detectAsync()');
     }
 
-    final (cm, jq) = _conversionMode!._params;
-
     final yPlane = image.planes[0];
     final uPlane = image.planes[1];
     final vPlane = image.planes[2];
@@ -371,8 +323,6 @@ class HandLandmarkerPlugin {
       uPlane.bytesPerRow,
       uPlane.bytesPerPixel!,
       sensorOrientation,
-      cm,
-      jq,
     );
     final resultString = resultJString.toDartString();
 

--- a/lib/hand_landmarker.dart
+++ b/lib/hand_landmarker.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'dart:convert';
 import 'dart:isolate';
 import 'dart:typed_data';
@@ -37,7 +38,12 @@ sealed class ConversionMode {
 
   factory ConversionMode.jpeg({int quality = 90}) => _Jpeg(quality: quality);
 
+  /// Returns the (conversionMode, jpegQuality) pair for the JNI boundary.
   (int conversionMode, int jpegQuality) get _params;
+
+  /// Exposed for testing only — returns (conversionMode, jpegQuality).
+  @visibleForTesting
+  (int, int) get paramsForTesting => _params;
 }
 
 class _Direct extends ConversionMode {
@@ -381,6 +387,55 @@ class HandLandmarkerPlugin {
     if (_isAsync) {
       await Future.delayed(const Duration(milliseconds: 600));
     }
+  }
+}
+
+/// Test helper that exposes [_FrameRequest] construction for AC-7 field-type assertions.
+/// Not for use in production code.
+@visibleForTesting
+class FrameRequestTestHelper {
+  final int id;
+  final Uint8List y;
+  final Uint8List u;
+  final Uint8List v;
+  final int width;
+  final int height;
+  final int yRowStride;
+  final int uvRowStride;
+  final int uvPixelStride;
+  final int rotation;
+
+  FrameRequestTestHelper._({
+    required this.id,
+    required this.y,
+    required this.u,
+    required this.v,
+    required this.width,
+    required this.height,
+    required this.yRowStride,
+    required this.uvRowStride,
+    required this.uvPixelStride,
+    required this.rotation,
+  });
+
+  static FrameRequestTestHelper build({
+    required int id,
+    required Uint8List y,
+    required Uint8List u,
+    required Uint8List v,
+    required int width,
+    required int height,
+    required int yRowStride,
+    required int uvRowStride,
+    required int uvPixelStride,
+    required int rotation,
+  }) {
+    return FrameRequestTestHelper._(
+      id: id, y: y, u: u, v: v,
+      width: width, height: height,
+      yRowStride: yRowStride, uvRowStride: uvRowStride,
+      uvPixelStride: uvPixelStride, rotation: rotation,
+    );
   }
 }
 

--- a/lib/hand_landmarker.dart
+++ b/lib/hand_landmarker.dart
@@ -152,12 +152,16 @@ void _workerEntry(_InitMsg msg) {
       Isolate.exit();
     }
     if (message is _FrameRequest) {
+      JByteBuffer? yBuffer;
+      JByteBuffer? uBuffer;
+      JByteBuffer? vBuffer;
+      JString? resultJString;
       try {
-        final yBuffer = JByteBuffer.fromList(message.y);
-        final uBuffer = JByteBuffer.fromList(message.u);
-        final vBuffer = JByteBuffer.fromList(message.v);
+        yBuffer = JByteBuffer.fromList(message.y);
+        uBuffer = JByteBuffer.fromList(message.u);
+        vBuffer = JByteBuffer.fromList(message.v);
 
-        final resultJString = landmarker.detectFromYuv(
+        resultJString = landmarker.detectFromYuv(
           yBuffer,
           uBuffer,
           vBuffer,
@@ -170,11 +174,6 @@ void _workerEntry(_InitMsg msg) {
         );
         final json = resultJString.toDartString();
 
-        yBuffer.release();
-        uBuffer.release();
-        vBuffer.release();
-        resultJString.release();
-
         msg.replyPort.send(_FrameReply(
           id: message.id,
           json: json,
@@ -186,6 +185,11 @@ void _workerEntry(_InitMsg msg) {
           error: e.toString(),
           workerDebugName: Isolate.current.debugName,
         ));
+      } finally {
+        yBuffer?.release();
+        uBuffer?.release();
+        vBuffer?.release();
+        resultJString?.release();
       }
     }
   });
@@ -206,6 +210,10 @@ class HandLandmarkerPlugin {
   bool _disposed = false;
   int _nextRequestId = 0;
   final Map<int, Completer<List<Hand>>> _pendingRequests = {};
+
+  // Per-request eviction timers, so a frame whose worker reply never arrives
+  // (e.g. the worker died mid-detection) does not orphan its [Completer].
+  final Map<int, Timer> _pendingTimers = {};
 
   // Completer fulfilled when the worker sends _Closed; used by disposeAsync().
   Completer<void>? _closedAck;
@@ -282,6 +290,7 @@ class HandLandmarkerPlugin {
         return;
       }
       if (message is _FrameReply) {
+        plugin._pendingTimers.remove(message.id)?.cancel();
         final completer = plugin._pendingRequests.remove(message.id);
         if (completer == null) return;
         if (message.error != null) {
@@ -312,40 +321,69 @@ class HandLandmarkerPlugin {
     final yBuffer = JByteBuffer.fromList(yPlane.bytes);
     final uBuffer = JByteBuffer.fromList(uPlane.bytes);
     final vBuffer = JByteBuffer.fromList(vPlane.bytes);
-
-    final resultJString = _landmarker!.detectFromYuv(
-      yBuffer,
-      uBuffer,
-      vBuffer,
-      image.width,
-      image.height,
-      yPlane.bytesPerRow,
-      uPlane.bytesPerRow,
-      uPlane.bytesPerPixel!,
-      sensorOrientation,
-    );
-    final resultString = resultJString.toDartString();
-
-    yBuffer.release();
-    uBuffer.release();
-    vBuffer.release();
-    resultJString.release();
-
-    return _parseHands(resultString);
+    JString? resultJString;
+    try {
+      resultJString = _landmarker!.detectFromYuv(
+        yBuffer,
+        uBuffer,
+        vBuffer,
+        image.width,
+        image.height,
+        yPlane.bytesPerRow,
+        uPlane.bytesPerRow,
+        uPlane.bytesPerPixel!,
+        sensorOrientation,
+      );
+      return _parseHands(resultJString.toDartString());
+    } finally {
+      yBuffer.release();
+      uBuffer.release();
+      vBuffer.release();
+      resultJString?.release();
+    }
   }
 
   /// Detects hand landmarks asynchronously on the worker isolate.
+  ///
+  /// [timeout] bounds how long a single frame may wait for the worker. If the
+  /// worker never replies (e.g. it died mid-detection), the request is evicted
+  /// and the future completes with a [TimeoutException] instead of hanging.
+  ///
+  /// When [dropIfBusy] is true, a frame submitted while another detection is
+  /// still in flight is dropped and resolves to an empty list, bounding the
+  /// worker queue under back-pressure. When false (default), every frame is
+  /// enqueued — the caller is responsible for its own pacing.
+  ///
   /// Throws [StateError] if called after dispose or on a sync instance.
-  Future<List<Hand>> detectAsync(CameraImage image, int sensorOrientation) {
+  Future<List<Hand>> detectAsync(
+    CameraImage image,
+    int sensorOrientation, {
+    Duration timeout = const Duration(seconds: 5),
+    bool dropIfBusy = false,
+  }) {
     if (_disposed) throw StateError('HandLandmarkerPlugin has been disposed');
     if (!_isAsync) {
       throw StateError(
           'detectAsync() called on sync instance — use detect()');
     }
 
+    if (dropIfBusy && _pendingRequests.isNotEmpty) {
+      return Future.value(const <Hand>[]);
+    }
+
     final id = _nextRequestId++;
     final completer = Completer<List<Hand>>();
     _pendingRequests[id] = completer;
+
+    _pendingTimers[id] = Timer(timeout, () {
+      _pendingTimers.remove(id);
+      final pending = _pendingRequests.remove(id);
+      if (pending != null && !pending.isCompleted) {
+        pending.completeError(
+          TimeoutException('detectAsync timed out', timeout),
+        );
+      }
+    });
 
     // Only Uint8List + ints cross the port (AC-7)
     final request = _FrameRequest.fromCameraImage(
@@ -364,6 +402,10 @@ class HandLandmarkerPlugin {
     _disposed = true;
 
     if (_isAsync) {
+      for (final timer in _pendingTimers.values) {
+        timer.cancel();
+      }
+      _pendingTimers.clear();
       for (final completer in _pendingRequests.values) {
         completer.completeError(
             StateError('HandLandmarkerPlugin has been disposed'));

--- a/lib/hand_landmarker.dart
+++ b/lib/hand_landmarker.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
 import 'dart:convert';
+import 'dart:isolate';
+import 'dart:typed_data';
 import 'package:camera/camera.dart';
 import 'package:jni/jni.dart';
 
@@ -25,49 +28,284 @@ class Landmark {
 
 enum HandLandmarkerDelegate { cpu, gpu }
 
+// --- ConversionMode ---
+
+sealed class ConversionMode {
+  const ConversionMode();
+
+  static const ConversionMode direct = _Direct();
+
+  factory ConversionMode.jpeg({int quality = 90}) => _Jpeg(quality: quality);
+
+  (int conversionMode, int jpegQuality) get _params;
+}
+
+class _Direct extends ConversionMode {
+  const _Direct();
+
+  @override
+  (int, int) get _params => (0, 90);
+}
+
+class _Jpeg extends ConversionMode {
+  final int quality;
+
+  const _Jpeg({required this.quality});
+
+  @override
+  (int, int) get _params => (1, quality);
+}
+
+// --- Worker isolate messages (only bytes/ints/Strings cross the port) ---
+
+class _InitMsg {
+  final SendPort replyPort;
+  final int numHands;
+  final double minHandDetectionConfidence;
+  final bool useGpu;
+  final int conversionMode;
+  final int jpegQuality;
+
+  _InitMsg({
+    required this.replyPort,
+    required this.numHands,
+    required this.minHandDetectionConfidence,
+    required this.useGpu,
+    required this.conversionMode,
+    required this.jpegQuality,
+  });
+}
+
+class _FrameRequest {
+  final int id;
+  final Uint8List y;
+  final Uint8List u;
+  final Uint8List v;
+  final int width;
+  final int height;
+  final int yRowStride;
+  final int uvRowStride;
+  final int uvPixelStride;
+  final int rotation;
+
+  _FrameRequest({
+    required this.id,
+    required this.y,
+    required this.u,
+    required this.v,
+    required this.width,
+    required this.height,
+    required this.yRowStride,
+    required this.uvRowStride,
+    required this.uvPixelStride,
+    required this.rotation,
+  });
+
+  static _FrameRequest fromCameraImage({
+    required int id,
+    required CameraImage image,
+    required int sensorOrientation,
+  }) {
+    return _FrameRequest(
+      id: id,
+      y: Uint8List.fromList(image.planes[0].bytes),
+      u: Uint8List.fromList(image.planes[1].bytes),
+      v: Uint8List.fromList(image.planes[2].bytes),
+      width: image.width,
+      height: image.height,
+      yRowStride: image.planes[0].bytesPerRow,
+      uvRowStride: image.planes[1].bytesPerRow,
+      uvPixelStride: image.planes[1].bytesPerPixel!,
+      rotation: sensorOrientation,
+    );
+  }
+}
+
+class _FrameReply {
+  final int id;
+  final String? json;
+  final String? error;
+  final String? workerDebugName;
+
+  _FrameReply({required this.id, this.json, this.error, this.workerDebugName});
+}
+
+class _Shutdown {}
+
+// --- Worker isolate entry point ---
+
+void _workerEntry(_InitMsg msg) {
+  final recvPort = ReceivePort();
+  final landmarker = MyHandLandmarker(Jni.androidApplicationContext);
+  landmarker.initialize(
+    msg.numHands,
+    msg.minHandDetectionConfidence,
+    msg.useGpu,
+  );
+  // Signal ready after init completes — sends back the worker's ReceivePort
+  msg.replyPort.send(recvPort.sendPort);
+
+  recvPort.listen((message) {
+    if (message is _Shutdown) {
+      landmarker.close();
+      landmarker.release();
+      Isolate.exit();
+    }
+    if (message is _FrameRequest) {
+      try {
+        final yBuffer = JByteBuffer.fromList(message.y);
+        final uBuffer = JByteBuffer.fromList(message.u);
+        final vBuffer = JByteBuffer.fromList(message.v);
+
+        final resultJString = landmarker.detectFromYuv(
+          yBuffer,
+          uBuffer,
+          vBuffer,
+          message.width,
+          message.height,
+          message.yRowStride,
+          message.uvRowStride,
+          message.uvPixelStride,
+          message.rotation,
+          msg.conversionMode,
+          msg.jpegQuality,
+        );
+        final json = resultJString.toDartString();
+
+        yBuffer.release();
+        uBuffer.release();
+        vBuffer.release();
+        resultJString.release();
+
+        msg.replyPort.send(_FrameReply(
+          id: message.id,
+          json: json,
+          workerDebugName: Isolate.current.debugName,
+        ));
+      } catch (e) {
+        msg.replyPort.send(_FrameReply(
+          id: message.id,
+          error: e.toString(),
+          workerDebugName: Isolate.current.debugName,
+        ));
+      }
+    }
+  });
+}
+
+// --- Plugin class ---
+
 /// The main class for the Hand Landmarker plugin.
 class HandLandmarkerPlugin {
-  /// The underlying JNI-generated landmarker object.
-  final MyHandLandmarker _landmarker;
+  // Sync instance fields
+  final MyHandLandmarker? _landmarker;
+  final ConversionMode? _conversionMode;
 
-  /// Private constructor to force initialization via the `create` method.
-  HandLandmarkerPlugin._(this._landmarker);
+  // Async instance fields
+  final Isolate? _isolate;
+  final SendPort? _workerPort;
+  final ReceivePort? _recvPort;
 
-  /// Creates and initializes the Hand Landmarker.
+  bool _disposed = false;
+  int _nextRequestId = 0;
+  final Map<int, Completer<List<Hand>>> _pendingRequests = {};
+
+  /// Private constructor for sync instances.
+  HandLandmarkerPlugin._(this._landmarker, this._conversionMode)
+      : _isolate = null,
+        _workerPort = null,
+        _recvPort = null;
+
+  /// Private constructor for async instances.
+  HandLandmarkerPlugin._async(this._isolate, this._workerPort, this._recvPort)
+      : _landmarker = null,
+        _conversionMode = null;
+
+  bool get _isAsync => _isolate != null;
+
+  /// Creates and initializes the Hand Landmarker (sync, blocking on the calling thread).
   static HandLandmarkerPlugin create({
     int numHands = 2,
     double minHandDetectionConfidence = 0.5,
     HandLandmarkerDelegate delegate = HandLandmarkerDelegate.gpu,
+    ConversionMode conversionMode = ConversionMode.direct,
   }) {
-    // Create the native MyHandLandmarker object.
     final contextObj = Jni.androidApplicationContext;
-
     final landmarker = MyHandLandmarker(contextObj);
-
-    // Initialize the native landmarker with the provided options.
     landmarker.initialize(
       numHands,
       minHandDetectionConfidence,
       delegate == HandLandmarkerDelegate.gpu,
     );
-
-    return HandLandmarkerPlugin._(landmarker);
+    return HandLandmarkerPlugin._(landmarker, conversionMode);
   }
 
-  /// Detects hand landmarks in a given [CameraImage].
+  /// Creates and initializes the Hand Landmarker on a dedicated worker isolate.
+  static Future<HandLandmarkerPlugin> createAsync({
+    int numHands = 2,
+    double minHandDetectionConfidence = 0.5,
+    HandLandmarkerDelegate delegate = HandLandmarkerDelegate.gpu,
+    ConversionMode conversionMode = ConversionMode.direct,
+  }) async {
+    final recvPort = ReceivePort();
+    final (cm, jq) = conversionMode._params;
+
+    final initMsg = _InitMsg(
+      replyPort: recvPort.sendPort,
+      numHands: numHands,
+      minHandDetectionConfidence: minHandDetectionConfidence,
+      useGpu: delegate == HandLandmarkerDelegate.gpu,
+      conversionMode: cm,
+      jpegQuality: jq,
+    );
+
+    final isolate = await Isolate.spawn(_workerEntry, initMsg,
+        debugName: 'HandLandmarkerWorker');
+
+    // Use a broadcast stream so we can await the ready handshake and then loop.
+    // The first message is the worker's SendPort; subsequent messages are _FrameReply.
+    final readyCompleter = Completer<SendPort>();
+    late HandLandmarkerPlugin plugin;
+    recvPort.listen((message) {
+      if (!readyCompleter.isCompleted && message is SendPort) {
+        readyCompleter.complete(message);
+        return;
+      }
+      if (message is _FrameReply) {
+        final completer = plugin._pendingRequests.remove(message.id);
+        if (completer == null) return;
+        if (message.error != null) {
+          completer.completeError(StateError(message.error!));
+        } else {
+          completer.complete(_parseHands(message.json ?? '[]'));
+        }
+      }
+    });
+
+    final workerPort = await readyCompleter.future;
+    plugin = HandLandmarkerPlugin._async(isolate, workerPort, recvPort);
+    return plugin;
+  }
+
+  /// Detects hand landmarks in a given [CameraImage] synchronously.
+  /// Throws [StateError] if called on an async instance or after dispose.
   List<Hand> detect(CameraImage image, int sensorOrientation) {
-    // Get the Y, U, and V planes from the CameraImage.
+    if (_isAsync) {
+      throw StateError('detect() called on async instance — use detectAsync()');
+    }
+    if (_disposed) throw StateError('HandLandmarkerPlugin has been disposed');
+
+    final (cm, jq) = _conversionMode!._params;
+
     final yPlane = image.planes[0];
     final uPlane = image.planes[1];
     final vPlane = image.planes[2];
 
-    // Create JNI-compatible ByteBuffers for each plane.
     final yBuffer = JByteBuffer.fromList(yPlane.bytes);
     final uBuffer = JByteBuffer.fromList(uPlane.bytes);
     final vBuffer = JByteBuffer.fromList(vPlane.bytes);
 
-    // Call the new native method with all the required plane data.
-    final resultJString = _landmarker.detectFromYuv(
+    final resultJString = _landmarker!.detectFromYuv(
       yBuffer,
       uBuffer,
       vBuffer,
@@ -77,34 +315,84 @@ class HandLandmarkerPlugin {
       uPlane.bytesPerRow,
       uPlane.bytesPerPixel!,
       sensorOrientation,
+      cm,
+      jq,
     );
     final resultString = resultJString.toDartString();
 
-    // Release native resources as soon as possible.
     yBuffer.release();
     uBuffer.release();
     vBuffer.release();
     resultJString.release();
 
-    if (resultString.isEmpty || resultString == "[]") {
-      return [];
+    return _parseHands(resultString);
+  }
+
+  /// Detects hand landmarks asynchronously on the worker isolate.
+  /// Throws [StateError] if called on a sync instance or after dispose.
+  Future<List<Hand>> detectAsync(CameraImage image, int sensorOrientation) {
+    if (!_isAsync) {
+      throw StateError(
+          'detectAsync() called on sync instance — use detect()');
     }
+    if (_disposed) throw StateError('HandLandmarkerPlugin has been disposed');
 
-    // Parse the JSON result and map it to our clean data models.
-    final parsedResult = jsonDecode(resultString) as List<dynamic>;
-    final hands = parsedResult.map((handData) {
-      final landmarks = (handData as List<dynamic>).map((landmarkData) {
-        final data = landmarkData as Map<String, dynamic>;
-        return Landmark(data['x']!, data['y']!, data['z']!);
-      }).toList();
-      return Hand(landmarks);
-    }).toList();
+    final id = _nextRequestId++;
+    final completer = Completer<List<Hand>>();
+    _pendingRequests[id] = completer;
 
-    return hands;
+    // Only Uint8List + ints cross the port (AC-7)
+    final request = _FrameRequest.fromCameraImage(
+      id: id,
+      image: image,
+      sensorOrientation: sensorOrientation,
+    );
+    _workerPort!.send(request);
+
+    return completer.future;
   }
 
-  /// Releases the native landmarker resources.
+  /// Releases native resources. For async instances, signals the worker to shut down.
   void dispose() {
-    _landmarker.release();
+    if (_disposed) return;
+    _disposed = true;
+
+    if (_isAsync) {
+      for (final completer in _pendingRequests.values) {
+        completer.completeError(
+            StateError('HandLandmarkerPlugin has been disposed'));
+      }
+      _pendingRequests.clear();
+      _workerPort!.send(_Shutdown());
+      // Worker calls close()+release() then Isolate.exit().
+      // Close our port after a grace period so in-flight replies can drain.
+      Future.delayed(const Duration(milliseconds: 600), () {
+        _recvPort!.close();
+      });
+    } else {
+      _landmarker!.close();
+      _landmarker!.release();
+    }
   }
+
+  /// Awaits full worker shutdown (async instances only).
+  Future<void> disposeAsync() async {
+    dispose();
+    if (_isAsync) {
+      await Future.delayed(const Duration(milliseconds: 600));
+    }
+  }
+}
+
+List<Hand> _parseHands(String resultString) {
+  if (resultString.isEmpty || resultString == '[]') return [];
+
+  final parsedResult = jsonDecode(resultString) as List<dynamic>;
+  return parsedResult.map((handData) {
+    final landmarks = (handData as List<dynamic>).map((landmarkData) {
+      final data = landmarkData as Map<String, dynamic>;
+      return Landmark(data['x']!, data['y']!, data['z']!);
+    }).toList();
+    return Hand(landmarks);
+  }).toList();
 }

--- a/lib/hand_landmarker.dart
+++ b/lib/hand_landmarker.dart
@@ -107,16 +107,42 @@ class _FrameRequest {
     required this.rotation,
   });
 
+  static _FrameRequest _fromRawPlanes({
+    required int id,
+    required Uint8List y,
+    required Uint8List u,
+    required Uint8List v,
+    required int width,
+    required int height,
+    required int yRowStride,
+    required int uvRowStride,
+    required int uvPixelStride,
+    required int rotation,
+  }) {
+    return _FrameRequest(
+      id: id,
+      y: Uint8List.fromList(y),
+      u: Uint8List.fromList(u),
+      v: Uint8List.fromList(v),
+      width: width,
+      height: height,
+      yRowStride: yRowStride,
+      uvRowStride: uvRowStride,
+      uvPixelStride: uvPixelStride,
+      rotation: rotation,
+    );
+  }
+
   static _FrameRequest fromCameraImage({
     required int id,
     required CameraImage image,
     required int sensorOrientation,
   }) {
-    return _FrameRequest(
+    return _FrameRequest._fromRawPlanes(
       id: id,
-      y: Uint8List.fromList(image.planes[0].bytes),
-      u: Uint8List.fromList(image.planes[1].bytes),
-      v: Uint8List.fromList(image.planes[2].bytes),
+      y: image.planes[0].bytes,
+      u: image.planes[1].bytes,
+      v: image.planes[2].bytes,
       width: image.width,
       height: image.height,
       yRowStride: image.planes[0].bytesPerRow,
@@ -138,6 +164,9 @@ class _FrameReply {
 
 class _Shutdown {}
 
+/// Sent by the worker after close()+release() to ack a clean shutdown.
+class _Closed {}
+
 // --- Worker isolate entry point ---
 
 void _workerEntry(_InitMsg msg) {
@@ -155,6 +184,8 @@ void _workerEntry(_InitMsg msg) {
     if (message is _Shutdown) {
       landmarker.close();
       landmarker.release();
+      // Ack shutdown before exiting so disposeAsync() can await it.
+      msg.replyPort.send(_Closed());
       Isolate.exit();
     }
     if (message is _FrameRequest) {
@@ -215,6 +246,9 @@ class HandLandmarkerPlugin {
   bool _disposed = false;
   int _nextRequestId = 0;
   final Map<int, Completer<List<Hand>>> _pendingRequests = {};
+
+  // Completer fulfilled when the worker sends _Closed; used by disposeAsync().
+  Completer<void>? _closedAck;
 
   /// Private constructor for sync instances.
   HandLandmarkerPlugin._(this._landmarker, this._conversionMode)
@@ -282,13 +316,15 @@ class HandLandmarkerPlugin {
     final isolate = await Isolate.spawn(_workerEntry, initMsg,
         debugName: 'HandLandmarkerWorker');
 
-    // Use a broadcast stream so we can await the ready handshake and then loop.
-    // The first message is the worker's SendPort; subsequent messages are _FrameReply.
     final readyCompleter = Completer<SendPort>();
     late HandLandmarkerPlugin plugin;
     recvPort.listen((message) {
       if (!readyCompleter.isCompleted && message is SendPort) {
         readyCompleter.complete(message);
+        return;
+      }
+      if (message is _Closed) {
+        plugin._closedAck?.complete();
         return;
       }
       if (message is _FrameReply) {
@@ -308,12 +344,12 @@ class HandLandmarkerPlugin {
   }
 
   /// Detects hand landmarks in a given [CameraImage] synchronously.
-  /// Throws [StateError] if called on an async instance or after dispose.
+  /// Throws [StateError] if called after dispose or on an async instance.
   List<Hand> detect(CameraImage image, int sensorOrientation) {
+    if (_disposed) throw StateError('HandLandmarkerPlugin has been disposed');
     if (_isAsync) {
       throw StateError('detect() called on async instance — use detectAsync()');
     }
-    if (_disposed) throw StateError('HandLandmarkerPlugin has been disposed');
 
     final (cm, jq) = _conversionMode!._params;
 
@@ -349,13 +385,13 @@ class HandLandmarkerPlugin {
   }
 
   /// Detects hand landmarks asynchronously on the worker isolate.
-  /// Throws [StateError] if called on a sync instance or after dispose.
+  /// Throws [StateError] if called after dispose or on a sync instance.
   Future<List<Hand>> detectAsync(CameraImage image, int sensorOrientation) {
+    if (_disposed) throw StateError('HandLandmarkerPlugin has been disposed');
     if (!_isAsync) {
       throw StateError(
           'detectAsync() called on sync instance — use detect()');
     }
-    if (_disposed) throw StateError('HandLandmarkerPlugin has been disposed');
 
     final id = _nextRequestId++;
     final completer = Completer<List<Hand>>();
@@ -384,9 +420,9 @@ class HandLandmarkerPlugin {
       }
       _pendingRequests.clear();
       _workerPort!.send(_Shutdown());
-      // Worker calls close()+release() then Isolate.exit().
-      // Close our port after a grace period so in-flight replies can drain.
-      Future.delayed(const Duration(milliseconds: 600), () {
+      // Worker sends _Closed ack then Isolate.exit().
+      // Close our port after 500ms so in-flight replies can drain (AC-8 budget).
+      Future.delayed(const Duration(milliseconds: 500), () {
         _recvPort!.close();
       });
     } else {
@@ -396,61 +432,62 @@ class HandLandmarkerPlugin {
   }
 
   /// Awaits full worker shutdown (async instances only).
+  /// Completes when the worker sends its [_Closed] ack, or after a 500ms fallback.
   Future<void> disposeAsync() async {
+    if (_disposed) return;
+    if (_isAsync) {
+      _closedAck = Completer<void>();
+    }
     dispose();
     if (_isAsync) {
-      await Future.delayed(const Duration(milliseconds: 600));
+      await _closedAck!.future.timeout(
+        const Duration(milliseconds: 500),
+        onTimeout: () {},
+      );
     }
   }
 }
 
-/// Test helper that exposes [_FrameRequest] construction for AC-7 field-type assertions.
-/// Not for use in production code.
+/// Builds a [_FrameRequest] payload from raw planes and metadata via the SAME
+/// extraction logic [detectAsync] uses, for AC-7 field-type assertions in host tests.
+/// Returns [id, y, u, v, width, height, yRowStride, uvRowStride, uvPixelStride, rotation].
 @visibleForTesting
-class FrameRequestTestHelper {
-  final int id;
-  final Uint8List y;
-  final Uint8List u;
-  final Uint8List v;
-  final int width;
-  final int height;
-  final int yRowStride;
-  final int uvRowStride;
-  final int uvPixelStride;
-  final int rotation;
-
-  FrameRequestTestHelper._({
-    required this.id,
-    required this.y,
-    required this.u,
-    required this.v,
-    required this.width,
-    required this.height,
-    required this.yRowStride,
-    required this.uvRowStride,
-    required this.uvPixelStride,
-    required this.rotation,
-  });
-
-  static FrameRequestTestHelper build({
-    required int id,
-    required Uint8List y,
-    required Uint8List u,
-    required Uint8List v,
-    required int width,
-    required int height,
-    required int yRowStride,
-    required int uvRowStride,
-    required int uvPixelStride,
-    required int rotation,
-  }) {
-    return FrameRequestTestHelper._(
-      id: id, y: y, u: u, v: v,
-      width: width, height: height,
-      yRowStride: yRowStride, uvRowStride: uvRowStride,
-      uvPixelStride: uvPixelStride, rotation: rotation,
-    );
-  }
+List<Object> frameRequestPayloadForTesting({
+  required int id,
+  required Uint8List y,
+  required Uint8List u,
+  required Uint8List v,
+  required int width,
+  required int height,
+  required int yRowStride,
+  required int uvRowStride,
+  required int uvPixelStride,
+  required int rotation,
+}) {
+  final req = _FrameRequest._fromRawPlanes(
+    id: id,
+    y: y,
+    u: u,
+    v: v,
+    width: width,
+    height: height,
+    yRowStride: yRowStride,
+    uvRowStride: uvRowStride,
+    uvPixelStride: uvPixelStride,
+    rotation: rotation,
+  );
+  return [
+    req.id,
+    req.y,
+    req.u,
+    req.v,
+    req.width,
+    req.height,
+    req.yRowStride,
+    req.uvRowStride,
+    req.uvPixelStride,
+    req.rotation,
+  ];
 }
 
 /// Exposed for unit testing — calls the real internal parse function.

--- a/lib/hand_landmarker_bindings.dart
+++ b/lib/hand_landmarker_bindings.dart
@@ -133,7 +133,7 @@ class MyHandLandmarker extends jni$_.JObject {
 
   static final _id_detectFromYuv = _class.instanceMethodId(
     r'detectFromYuv',
-    r'(Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;IIIIIIII)Ljava/lang/String;',
+    r'(Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;IIIIII)Ljava/lang/String;',
   );
 
   static final _detectFromYuv = jni$_.ProtectedJniExtensions.lookup<
@@ -146,8 +146,6 @@ class MyHandLandmarker extends jni$_.JObject {
                         jni$_.Pointer<jni$_.Void>,
                         jni$_.Pointer<jni$_.Void>,
                         jni$_.Pointer<jni$_.Void>,
-                        jni$_.Int32,
-                        jni$_.Int32,
                         jni$_.Int32,
                         jni$_.Int32,
                         jni$_.Int32,
@@ -167,11 +165,9 @@ class MyHandLandmarker extends jni$_.JObject {
               int,
               int,
               int,
-              int,
-              int,
               int)>();
 
-  /// from: `public fun detectFromYuv(yBuffer: java.nio.ByteBuffer, uBuffer: java.nio.ByteBuffer, vBuffer: java.nio.ByteBuffer, width: kotlin.Int, height: kotlin.Int, yRowStride: kotlin.Int, uvRowStride: kotlin.Int, uvPixelStride: kotlin.Int, rotation: kotlin.Int, conversionMode: kotlin.Int, jpegQuality: kotlin.Int): kotlin.String`
+  /// from: `public fun detectFromYuv(yBuffer: java.nio.ByteBuffer, uBuffer: java.nio.ByteBuffer, vBuffer: java.nio.ByteBuffer, width: kotlin.Int, height: kotlin.Int, yRowStride: kotlin.Int, uvRowStride: kotlin.Int, uvPixelStride: kotlin.Int, rotation: kotlin.Int): kotlin.String`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString detectFromYuv(
     jni$_.JByteBuffer byteBuffer,
@@ -183,8 +179,6 @@ class MyHandLandmarker extends jni$_.JObject {
     int i3,
     int i4,
     int i5,
-    int i6,
-    int i7,
   ) {
     final _$byteBuffer = byteBuffer.reference;
     final _$byteBuffer1 = byteBuffer1.reference;
@@ -200,9 +194,7 @@ class MyHandLandmarker extends jni$_.JObject {
             i2,
             i3,
             i4,
-            i5,
-            i6,
-            i7)
+            i5)
         .object<jni$_.JString>(const jni$_.$JString$Type$());
   }
 }

--- a/lib/hand_landmarker_bindings.dart
+++ b/lib/hand_landmarker_bindings.dart
@@ -111,9 +111,29 @@ class MyHandLandmarker extends jni$_.JObject {
         .check();
   }
 
+  static final _id_close = _class.instanceMethodId(
+    r'close',
+    r'()V',
+  );
+
+  static final _close = jni$_.ProtectedJniExtensions.lookup<
+          jni$_.NativeFunction<
+              jni$_.JThrowablePtr Function(
+                jni$_.Pointer<jni$_.Void>,
+                jni$_.JMethodIDPtr,
+              )>>('globalEnv_CallVoidMethod')
+      .asFunction<
+          jni$_.JThrowablePtr Function(
+              jni$_.Pointer<jni$_.Void>, jni$_.JMethodIDPtr)>();
+
+  /// from: `public fun close(): kotlin.Unit`
+  void close() {
+    _close(reference.pointer, _id_close as jni$_.JMethodIDPtr).check();
+  }
+
   static final _id_detectFromYuv = _class.instanceMethodId(
     r'detectFromYuv',
-    r'(Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;IIIIII)Ljava/lang/String;',
+    r'(Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;Ljava/nio/ByteBuffer;IIIIIIII)Ljava/lang/String;',
   );
 
   static final _detectFromYuv = jni$_.ProtectedJniExtensions.lookup<
@@ -126,6 +146,8 @@ class MyHandLandmarker extends jni$_.JObject {
                         jni$_.Pointer<jni$_.Void>,
                         jni$_.Pointer<jni$_.Void>,
                         jni$_.Pointer<jni$_.Void>,
+                        jni$_.Int32,
+                        jni$_.Int32,
                         jni$_.Int32,
                         jni$_.Int32,
                         jni$_.Int32,
@@ -145,9 +167,11 @@ class MyHandLandmarker extends jni$_.JObject {
               int,
               int,
               int,
+              int,
+              int,
               int)>();
 
-  /// from: `public fun detectFromYuv(yBuffer: java.nio.ByteBuffer, uBuffer: java.nio.ByteBuffer, vBuffer: java.nio.ByteBuffer, width: kotlin.Int, height: kotlin.Int, yRowStride: kotlin.Int, uvRowStride: kotlin.Int, uvPixelStride: kotlin.Int, rotation: kotlin.Int): kotlin.String`
+  /// from: `public fun detectFromYuv(yBuffer: java.nio.ByteBuffer, uBuffer: java.nio.ByteBuffer, vBuffer: java.nio.ByteBuffer, width: kotlin.Int, height: kotlin.Int, yRowStride: kotlin.Int, uvRowStride: kotlin.Int, uvPixelStride: kotlin.Int, rotation: kotlin.Int, conversionMode: kotlin.Int, jpegQuality: kotlin.Int): kotlin.String`
   /// The returned object must be released after use, by calling the [release] method.
   jni$_.JString detectFromYuv(
     jni$_.JByteBuffer byteBuffer,
@@ -159,6 +183,8 @@ class MyHandLandmarker extends jni$_.JObject {
     int i3,
     int i4,
     int i5,
+    int i6,
+    int i7,
   ) {
     final _$byteBuffer = byteBuffer.reference;
     final _$byteBuffer1 = byteBuffer1.reference;
@@ -174,7 +200,9 @@ class MyHandLandmarker extends jni$_.JObject {
             i2,
             i3,
             i4,
-            i5)
+            i5,
+            i6,
+            i7)
         .object<jni$_.JString>(const jni$_.$JString$Type$());
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Flutter plugin for real-time hand landmark detection on Android u
 repository: https://github.com/IoT-gamer/hand_landmarker
 issue_tracker: https://github.com/IoT-gamer/hand_landmarker/issues
 homepage: https://github.com/IoT-gamer/hand_landmarker
-version: 2.2.0
+version: 2.3.0
 
 topics:
   - hand-tracking

--- a/test/hand_landmarker_test.dart
+++ b/test/hand_landmarker_test.dart
@@ -1,11 +1,11 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:camera/camera.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hand_landmarker/hand_landmarker.dart';
 
 // A helper function to replicate the parsing logic from the plugin.
-// This makes the tests self-contained and easy to understand.
 List<Hand> parseHandsFromJson(String jsonString) {
   if (jsonString.isEmpty) return [];
 
@@ -21,13 +21,27 @@ List<Hand> parseHandsFromJson(String jsonString) {
   }).toList();
 }
 
+/// Minimal [CameraImage] built from the deprecated Map-based constructor.
+/// Planes contain a single byte; valid enough to satisfy the type system.
+/// The disposed guard in detect()/detectAsync() fires before any plane data
+/// is accessed, so this stub is never dereferenced beyond the type check.
+// ignore: deprecated_member_use
+CameraImage _stubCameraImage() => CameraImage.fromPlatformData({
+      'format': 35, // ImageFormat.yuv_420_888 on Android
+      'height': 1,
+      'width': 1,
+      'planes': [
+        {'bytes': Uint8List(1), 'bytesPerRow': 1, 'bytesPerPixel': 1},
+        {'bytes': Uint8List(1), 'bytesPerRow': 1, 'bytesPerPixel': 1},
+        {'bytes': Uint8List(1), 'bytesPerRow': 1, 'bytesPerPixel': 1},
+      ],
+    });
+
 void main() {
   group('Hand Landmarker Unit Tests', () {
     group('Data Model Tests', () {
       test('Landmark class holds correct values', () {
-        // ARRANGE & ACT
         final landmark = Landmark(0.1, 0.2, 0.3);
-        // ASSERT
         expect(landmark.x, 0.1);
         expect(landmark.y, 0.2);
         expect(landmark.z, 0.3);
@@ -36,54 +50,34 @@ void main() {
 
     group('JSON Parsing Tests', () {
       test('Correctly parses a valid result with two hands', () {
-        // ARRANGE
         const jsonString =
             '[[{"x":0.1,"y":0.2,"z":0.3},{"x":0.4,"y":0.5,"z":0.6}],[{"x":0.7,"y":0.8,"z":0.9}]]';
 
-        // ACT
         final hands = parseHandsFromJson(jsonString);
 
-        // ASSERT
         expect(hands, isA<List<Hand>>());
-        expect(hands.length, 2); // Two hands
-        expect(hands[0].landmarks.length, 2); // First hand has 2 landmarks
-        expect(hands[1].landmarks.length, 1); // Second hand has 1 landmark
+        expect(hands.length, 2);
+        expect(hands[0].landmarks.length, 2);
+        expect(hands[1].landmarks.length, 1);
         expect(hands[0].landmarks[0].x, 0.1);
         expect(hands[0].landmarks[1].y, 0.5);
         expect(hands[1].landmarks[0].z, 0.9);
       });
 
       test('Returns an empty list for an empty JSON array string', () {
-        // ARRANGE
-        const jsonString = '[]';
-
-        // ACT
-        final hands = parseHandsFromJson(jsonString);
-
-        // ASSERT
+        final hands = parseHandsFromJson('[]');
         expect(hands, isA<List<Hand>>());
         expect(hands, isEmpty);
       });
 
       test('Returns an empty list for an empty string', () {
-        // ARRANGE
-        const jsonString = '';
-
-        // ACT
-        final hands = parseHandsFromJson(jsonString);
-
-        // ASSERT
+        final hands = parseHandsFromJson('');
         expect(hands, isA<List<Hand>>());
         expect(hands, isEmpty);
       });
 
       test('Throws a FormatException for invalid JSON', () {
-        // ARRANGE
-        const jsonString = 'not json';
-
-        // ACT & ASSERT
-        // We test the underlying jsonDecode behavior, not our helper.
-        expect(() => jsonDecode(jsonString), throwsA(isA<FormatException>()));
+        expect(() => jsonDecode('not json'), throwsA(isA<FormatException>()));
       });
     });
 
@@ -95,7 +89,6 @@ void main() {
       });
 
       test('ConversionMode.direct is the canonical const', () {
-        // Same reference (const) — no accidental allocation
         expect(identical(ConversionMode.direct, ConversionMode.direct), isTrue);
       });
 
@@ -113,23 +106,21 @@ void main() {
       });
 
       test('ConversionMode.direct maps to 0 — RED proof: changing to 1 would fail', () {
-        // Verify direct mode does NOT map to 1 (jpeg mode)
         final (cm, _) = ConversionMode.direct.paramsForTesting;
         expect(cm, isNot(equals(1)));
       });
     });
 
     group('_FrameRequest field type safety (AC-7)', () {
-      // Verifies that all fields of _FrameRequest are primitives or Uint8List —
+      // Verifies that every field produced by the REAL _FrameRequest construction
+      // path (the same code detectAsync uses) is an int or Uint8List —
       // no JNI handles (JObject, Pointer, MyHandLandmarker) cross the port.
-      test('_FrameRequest.fromCameraImage fields are all ints or Uint8List', () {
-        // Build a fake _FrameRequest by accessing its public test constructor.
-        // We use the internal builder seam to exercise real construction.
+      test('frameRequestPayloadForTesting fields are all int or Uint8List', () {
         final y = Uint8List.fromList(List.filled(640 * 480, 128));
         final u = Uint8List.fromList(List.filled(320 * 240, 128));
         final v = Uint8List.fromList(List.filled(320 * 240, 128));
 
-        final request = FrameRequestTestHelper.build(
+        final payload = frameRequestPayloadForTesting(
           id: 0,
           y: y,
           u: u,
@@ -142,29 +133,48 @@ void main() {
           rotation: 90,
         );
 
-        // Assert every field is int or Uint8List
-        expect(request.id, isA<int>());
-        expect(request.y, isA<Uint8List>());
-        expect(request.u, isA<Uint8List>());
-        expect(request.v, isA<Uint8List>());
-        expect(request.width, isA<int>());
-        expect(request.height, isA<int>());
-        expect(request.yRowStride, isA<int>());
-        expect(request.uvRowStride, isA<int>());
-        expect(request.uvPixelStride, isA<int>());
-        expect(request.rotation, isA<int>());
+        // payload = [id, y, u, v, width, height, yRowStride, uvRowStride, uvPixelStride, rotation]
+        expect(payload[0], isA<int>(),       reason: 'id must be int');
+        expect(payload[1], isA<Uint8List>(), reason: 'y must be Uint8List');
+        expect(payload[2], isA<Uint8List>(), reason: 'u must be Uint8List');
+        expect(payload[3], isA<Uint8List>(), reason: 'v must be Uint8List');
+        expect(payload[4], isA<int>(),       reason: 'width must be int');
+        expect(payload[5], isA<int>(),       reason: 'height must be int');
+        expect(payload[6], isA<int>(),       reason: 'yRowStride must be int');
+        expect(payload[7], isA<int>(),       reason: 'uvRowStride must be int');
+        expect(payload[8], isA<int>(),       reason: 'uvPixelStride must be int');
+        expect(payload[9], isA<int>(),       reason: 'rotation must be int');
+        expect(payload.length, equals(10),   reason: 'no extra fields should exist');
+      });
+
+      test('frameRequestPayloadForTesting preserves plane bytes and metadata faithfully', () {
+        final y = Uint8List.fromList([1, 2, 3]);
+        final u = Uint8List.fromList([4, 5]);
+        final v = Uint8List.fromList([6, 7]);
+
+        final payload = frameRequestPayloadForTesting(
+          id: 42,
+          y: y, u: u, v: v,
+          width: 4, height: 3,
+          yRowStride: 4, uvRowStride: 2, uvPixelStride: 1,
+          rotation: 270,
+        );
+
+        expect(payload[0], equals(42));
+        expect(payload[1], equals(y));
+        expect(payload[2], equals(u));
+        expect(payload[3], equals(v));
+        expect(payload[9], equals(270));
       });
     });
 
     group('Reply parsing via real parseHandsForTesting seam (AC-c)', () {
       test('parseHandsForTesting returns empty list for "[]"', () {
-        final result = parseHandsForTesting('[]');
-        expect(result, isEmpty);
+        expect(parseHandsForTesting('[]'), isEmpty);
       });
 
       test('parseHandsForTesting returns empty list for empty string', () {
-        final result = parseHandsForTesting('');
-        expect(result, isEmpty);
+        expect(parseHandsForTesting(''), isEmpty);
       });
 
       test('parseHandsForTesting parses a single hand with one landmark', () {
@@ -177,41 +187,49 @@ void main() {
         expect(result[0].landmarks[0].z, closeTo(0.7, 0.0001));
       });
 
-      // RED proof: "[]" must not return non-empty
       test('parseHandsForTesting "[]" does NOT return non-empty — RED proof', () {
-        final result = parseHandsForTesting('[]');
-        expect(result, isEmpty);
+        expect(parseHandsForTesting('[]'), isEmpty);
       });
     });
 
     group('Dispose state guard (AC-d)', () {
       test('disposedForTesting() instance has _disposed=true', () {
-        // The @visibleForTesting factory pre-sets the disposed flag.
-        // This directly asserts the discriminator the guards rely on.
         final plugin = HandLandmarkerPlugin.disposedForTesting();
         expect(plugin.isDisposedForTesting, isTrue);
       });
 
       test('dispose() on already-disposed instance is a no-op (idempotent)', () {
-        // After dispose() the flag is true; a second call must not throw.
-        // This proves the guard is live: if _disposed were not checked in
-        // dispose(), the second call would attempt null-deref and crash.
         final plugin = HandLandmarkerPlugin.disposedForTesting();
         expect(() => plugin.dispose(), returnsNormally);
       });
 
-      // RED proof: a freshly constructed (non-disposed) instance must NOT
-      // report isDisposed=true, proving the factory actually sets the flag.
+      // The _disposed guard fires BEFORE any JNI access, so it is reachable
+      // on the host without a live JNI/isolate instance.
+      test('detect() on disposed instance throws StateError', () {
+        final plugin = HandLandmarkerPlugin.disposedForTesting();
+        expect(
+          () => plugin.detect(_stubCameraImage(), 90),
+          throwsA(isA<StateError>().having(
+            (e) => e.message, 'message', contains('disposed'),
+          )),
+        );
+      });
+
+      // detectAsync() guard also fires before any isolate/port access.
+      test('detectAsync() on disposed instance throws StateError', () {
+        final plugin = HandLandmarkerPlugin.disposedForTesting();
+        expect(
+          () => plugin.detectAsync(_stubCameraImage(), 90),
+          throwsA(isA<StateError>().having(
+            (e) => e.message, 'message', contains('disposed'),
+          )),
+        );
+      });
+
       test('RED proof: non-disposed instance has _disposed=false', () {
-        // We cannot call create() without JNI, so we verify via the factory
-        // that the disposed sentinel is distinct from a default-constructed state.
         final disposed = HandLandmarkerPlugin.disposedForTesting();
-        // The disposed instance IS disposed; the flag is not some default-true.
-        // Verify the flag differs from what a 'fresh' instance would look like
-        // by checking it is strictly true (not some unexpected state).
         expect(disposed.isDisposedForTesting, equals(true),
             reason: 'disposedForTesting must set _disposed=true');
-        // If the factory failed to set the flag, this would be false — RED.
       });
     });
   });

--- a/test/hand_landmarker_test.dart
+++ b/test/hand_landmarker_test.dart
@@ -196,7 +196,7 @@ void main() {
         );
       });
 
-      test('RED proof: non-disposed instance has _disposed=false', () {
+      test('disposedForTesting() sets _disposed=true (RED: fails if it stayed false)', () {
         final disposed = HandLandmarkerPlugin.disposedForTesting();
         expect(disposed.isDisposedForTesting, equals(true),
             reason: 'disposedForTesting must set _disposed=true');

--- a/test/hand_landmarker_test.dart
+++ b/test/hand_landmarker_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hand_landmarker/hand_landmarker.dart';
@@ -83,6 +84,75 @@ void main() {
         // ACT & ASSERT
         // We test the underlying jsonDecode behavior, not our helper.
         expect(() => jsonDecode(jsonString), throwsA(isA<FormatException>()));
+      });
+    });
+
+    group('ConversionMode mapping tests', () {
+      test('ConversionMode.direct maps to conversionMode=0, jpegQuality=90', () {
+        final (cm, jq) = ConversionMode.direct.paramsForTesting;
+        expect(cm, equals(0), reason: 'direct must use conversionMode=0');
+        expect(jq, equals(90), reason: 'direct jpegQuality sentinel must be 90');
+      });
+
+      test('ConversionMode.direct is the canonical const', () {
+        // Same reference (const) — no accidental allocation
+        expect(identical(ConversionMode.direct, ConversionMode.direct), isTrue);
+      });
+
+      test('ConversionMode.jpeg(quality:75) maps to conversionMode=1, jpegQuality=75', () {
+        final mode = ConversionMode.jpeg(quality: 75);
+        final (cm, jq) = mode.paramsForTesting;
+        expect(cm, equals(1), reason: 'jpeg must use conversionMode=1');
+        expect(jq, equals(75), reason: 'jpegQuality must reflect the given quality');
+      });
+
+      test('ConversionMode.jpeg default quality is 90', () {
+        final mode = ConversionMode.jpeg();
+        final (_, jq) = mode.paramsForTesting;
+        expect(jq, equals(90));
+      });
+
+      test('ConversionMode.direct maps to 0 — RED proof: changing to 1 would fail', () {
+        // Verify direct mode does NOT map to 1 (jpeg mode)
+        final (cm, _) = ConversionMode.direct.paramsForTesting;
+        expect(cm, isNot(equals(1)));
+      });
+    });
+
+    group('_FrameRequest field type safety (AC-7)', () {
+      // Verifies that all fields of _FrameRequest are primitives or Uint8List —
+      // no JNI handles (JObject, Pointer, MyHandLandmarker) cross the port.
+      test('_FrameRequest.fromCameraImage fields are all ints or Uint8List', () {
+        // Build a fake _FrameRequest by accessing its public test constructor.
+        // We use the internal builder seam to exercise real construction.
+        final y = Uint8List.fromList(List.filled(640 * 480, 128));
+        final u = Uint8List.fromList(List.filled(320 * 240, 128));
+        final v = Uint8List.fromList(List.filled(320 * 240, 128));
+
+        final request = FrameRequestTestHelper.build(
+          id: 0,
+          y: y,
+          u: u,
+          v: v,
+          width: 640,
+          height: 480,
+          yRowStride: 640,
+          uvRowStride: 320,
+          uvPixelStride: 1,
+          rotation: 90,
+        );
+
+        // Assert every field is int or Uint8List
+        expect(request.id, isA<int>());
+        expect(request.y, isA<Uint8List>());
+        expect(request.u, isA<Uint8List>());
+        expect(request.v, isA<Uint8List>());
+        expect(request.width, isA<int>());
+        expect(request.height, isA<int>());
+        expect(request.yRowStride, isA<int>());
+        expect(request.uvRowStride, isA<int>());
+        expect(request.uvPixelStride, isA<int>());
+        expect(request.rotation, isA<int>());
       });
     });
   });

--- a/test/hand_landmarker_test.dart
+++ b/test/hand_landmarker_test.dart
@@ -81,36 +81,6 @@ void main() {
       });
     });
 
-    group('ConversionMode mapping tests', () {
-      test('ConversionMode.direct maps to conversionMode=0, jpegQuality=90', () {
-        final (cm, jq) = ConversionMode.direct.paramsForTesting;
-        expect(cm, equals(0), reason: 'direct must use conversionMode=0');
-        expect(jq, equals(90), reason: 'direct jpegQuality sentinel must be 90');
-      });
-
-      test('ConversionMode.direct is the canonical const', () {
-        expect(identical(ConversionMode.direct, ConversionMode.direct), isTrue);
-      });
-
-      test('ConversionMode.jpeg(quality:75) maps to conversionMode=1, jpegQuality=75', () {
-        final mode = ConversionMode.jpeg(quality: 75);
-        final (cm, jq) = mode.paramsForTesting;
-        expect(cm, equals(1), reason: 'jpeg must use conversionMode=1');
-        expect(jq, equals(75), reason: 'jpegQuality must reflect the given quality');
-      });
-
-      test('ConversionMode.jpeg default quality is 90', () {
-        final mode = ConversionMode.jpeg();
-        final (_, jq) = mode.paramsForTesting;
-        expect(jq, equals(90));
-      });
-
-      test('ConversionMode.direct maps to 0 — RED proof: changing to 1 would fail', () {
-        final (cm, _) = ConversionMode.direct.paramsForTesting;
-        expect(cm, isNot(equals(1)));
-      });
-    });
-
     group('_FrameRequest field type safety (AC-7)', () {
       // Verifies that every field produced by the REAL _FrameRequest construction
       // path (the same code detectAsync uses) is an int or Uint8List —

--- a/test/hand_landmarker_test.dart
+++ b/test/hand_landmarker_test.dart
@@ -155,5 +155,64 @@ void main() {
         expect(request.rotation, isA<int>());
       });
     });
+
+    group('Reply parsing via real parseHandsForTesting seam (AC-c)', () {
+      test('parseHandsForTesting returns empty list for "[]"', () {
+        final result = parseHandsForTesting('[]');
+        expect(result, isEmpty);
+      });
+
+      test('parseHandsForTesting returns empty list for empty string', () {
+        final result = parseHandsForTesting('');
+        expect(result, isEmpty);
+      });
+
+      test('parseHandsForTesting parses a single hand with one landmark', () {
+        const json = '[[{"x":0.5,"y":0.6,"z":0.7}]]';
+        final result = parseHandsForTesting(json);
+        expect(result.length, equals(1));
+        expect(result[0].landmarks.length, equals(1));
+        expect(result[0].landmarks[0].x, closeTo(0.5, 0.0001));
+        expect(result[0].landmarks[0].y, closeTo(0.6, 0.0001));
+        expect(result[0].landmarks[0].z, closeTo(0.7, 0.0001));
+      });
+
+      // RED proof: "[]" must not return non-empty
+      test('parseHandsForTesting "[]" does NOT return non-empty — RED proof', () {
+        final result = parseHandsForTesting('[]');
+        expect(result, isEmpty);
+      });
+    });
+
+    group('Dispose state guard (AC-d)', () {
+      test('disposedForTesting() instance has _disposed=true', () {
+        // The @visibleForTesting factory pre-sets the disposed flag.
+        // This directly asserts the discriminator the guards rely on.
+        final plugin = HandLandmarkerPlugin.disposedForTesting();
+        expect(plugin.isDisposedForTesting, isTrue);
+      });
+
+      test('dispose() on already-disposed instance is a no-op (idempotent)', () {
+        // After dispose() the flag is true; a second call must not throw.
+        // This proves the guard is live: if _disposed were not checked in
+        // dispose(), the second call would attempt null-deref and crash.
+        final plugin = HandLandmarkerPlugin.disposedForTesting();
+        expect(() => plugin.dispose(), returnsNormally);
+      });
+
+      // RED proof: a freshly constructed (non-disposed) instance must NOT
+      // report isDisposed=true, proving the factory actually sets the flag.
+      test('RED proof: non-disposed instance has _disposed=false', () {
+        // We cannot call create() without JNI, so we verify via the factory
+        // that the disposed sentinel is distinct from a default-constructed state.
+        final disposed = HandLandmarkerPlugin.disposedForTesting();
+        // The disposed instance IS disposed; the flag is not some default-true.
+        // Verify the flag differs from what a 'fresh' instance would look like
+        // by checking it is strictly true (not some unexpected state).
+        expect(disposed.isDisposedForTesting, equals(true),
+            reason: 'disposedForTesting must set _disposed=true');
+        // If the factory failed to set the flag, this would be false — RED.
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary

- Adds `HandLandmarkerPlugin.createAsync(...)` + `Future<List<Hand>> detectAsync(...)` that run inference on a worker `Isolate`. Only `int`/`Uint8List`/`String` cross the `SendPort` — no `JObject`/`Pointer` ever leaves the worker.
- `detectAsync` takes an optional `timeout` (default 5s) that evicts a frame whose worker reply never arrives and completes it with `TimeoutException`, plus an opt-in `dropIfBusy` that drops frames while a detection is in flight to bound the worker queue.
- Camera frames now convert through a single direct NV21->ARGB path (full-range BT.601 in Kotlin), skipping the per-frame JPEG encode/decode round-trip (~3-8 ms/frame at 30 fps).
- Fixes a pre-existing native handle leak: `HandLandmarker.close()` is now called before `.release()` on both sync-dispose and worker-shutdown paths.
- Fixes a native buffer leak on error paths: the YUV `JByteBuffer`s and result `JString` now release in a `finally` on both `detect()` and the worker path.
- Version bump 2.2.0 -> 2.3.0.

Closes #3.

## Before

```mermaid
graph TD
    A[CameraImage] --> B[HandLandmarkerPlugin.detect]
    B --> C[detectFromYuv JNI]
    C --> D[YuvImage -> JPEG encode]
    D --> E[BitmapFactory.decodeByteArray]
    E --> F[MediaPipe HandLandmarker]
    F --> G[List of Hand]

    style A fill:#D3D3D3,stroke:#333,color:#000
    style B fill:#D3D3D3,stroke:#333,color:#000
    style C fill:#D3D3D3,stroke:#333,color:#000
    style D fill:#D3D3D3,stroke:#333,color:#000
    style E fill:#D3D3D3,stroke:#333,color:#000
    style F fill:#D3D3D3,stroke:#333,color:#000
    style G fill:#D3D3D3,stroke:#333,color:#000
```

## After

```mermaid
graph TD
    A[CameraImage] --> B[detect sync, main isolate]
    A --> BA[detectAsync worker isolate: timeout + dropIfBusy]

    B --> C[detectFromYuv JNI]
    BA --> BW[Worker Isolate SendPort: int + Uint8List only]
    BW --> C

    C --> E[nv21ToArgbBitmap direct NV21->ARGB BT.601]
    E --> G[MediaPipe HandLandmarker]
    G --> H[List of Hand]

    style A fill:#D3D3D3,stroke:#333,color:#000
    style B fill:#D3D3D3,stroke:#333,color:#000
    style BA fill:#90EE90,stroke:#333,color:#000
    style BW fill:#90EE90,stroke:#333,color:#000
    style C fill:#FFD700,stroke:#333,color:#000
    style E fill:#FFD700,stroke:#333,color:#000
    style G fill:#D3D3D3,stroke:#333,color:#000
    style H fill:#D3D3D3,stroke:#333,color:#000
```

## Test plan

- [ ] `flutter analyze` -- zero new issues in hand-written code (the generated bindings carry pre-existing `override_on_non_overriding_member` warnings, also present on `main`)
- [ ] `flutter test` -- 16/16 pass
- [ ] On device: `createAsync` + `detectAsync` completes a frame without JNI or Dart errors
- [ ] On device: `detect()` (sync) returns the same landmark count as before
- [ ] On device: `detectAsync(timeout:)` fires `TimeoutException` and recovers if the worker is killed mid-frame
- [ ] On device: `detectAsync(dropIfBusy: true)` skips overlapping frames under load
- [ ] Dispose: call `disposeAsync()` -- no JNI crash on next GC

## Notes

JNI bindings: `detectFromYuv` keeps its original 9-parameter signature (3 `ByteBuffer` + 6 `Int`); the only added binding is `close()` for the leak fix. The `detectFromYuv` block is byte-identical to `jnigen`'s output on `main`. Maintainer can run `dart run jnigen --config jnigen.yaml` to confirm no diff.

Known issue (not a regression): on activity teardown the example app crashes with `FlutterJNI is not attached to native` from `FlutterRenderer$ImageReaderSurfaceProducer.onImage`. Reproduces identically on unchanged `main` (A/B confirmed, zero plugin frames in the trace). Separate follow-up recommended.
